### PR TITLE
Fix unresolved symbol AddFirewallBlockRule

### DIFF
--- a/NetSeal/firewall.cpp
+++ b/NetSeal/firewall.cpp
@@ -2,6 +2,9 @@
 #include <string>
 #include <windows.h>
 
+// Ensure the exported symbol uses C linkage to match the header
+extern "C" {
+
 // Adds a simple Windows Firewall rule to block outbound traffic for the
 // current process. Returns TRUE on success.
 BOOL AddFirewallBlockRule()
@@ -17,4 +20,5 @@ BOOL AddFirewallBlockRule()
     // Execute the command silently
     int result = _wsystem(command.c_str());
     return result == 0;
+}
 }


### PR DESCRIPTION
## Summary
- ensure AddFirewallBlockRule uses C linkage

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_684a185020f483309c2976188a02b2bf