### PR TITLE
Fix firewall rule addition

### DIFF
--- a/NetSeal/dllmain.cpp
+++ b/NetSeal/dllmain.cpp
@@ -1,6 +1,5 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "pch.h"
-#include "firewall.h"
 
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
@@ -10,7 +9,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     switch (ul_reason_for_call)
     {
     case DLL_PROCESS_ATTACH:
-        AddFirewallBlockRule();
+        // Rule creation is handled by the injector process
         break;
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:

--- a/NetSeal/firewall.cpp
+++ b/NetSeal/firewall.cpp
@@ -1,16 +1,16 @@
 #include "pch.h"
 #include <string>
 #include <windows.h>
+#include <wchar.h>
 
 // Ensure the exported symbol uses C linkage to match the header
 extern "C" {
 
-// Adds a simple Windows Firewall rule to block outbound traffic for the
-// current process. Returns TRUE on success.
-BOOL AddFirewallBlockRule()
+// Adds a Windows Firewall rule to block outbound traffic for the
+// specified executable path. Returns TRUE on success.
+BOOL AddFirewallBlockRule(const wchar_t* exePath)
 {
-    wchar_t exePath[MAX_PATH];
-    if (!GetModuleFileNameW(NULL, exePath, MAX_PATH))
+    if (!exePath || wcslen(exePath) == 0)
         return FALSE;
 
     std::wstring command = L"netsh advfirewall firewall add rule name=\"NetSealBlock\" program=\"";

--- a/NetSeal/firewall.h
+++ b/NetSeal/firewall.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-__declspec(dllexport) BOOL AddFirewallBlockRule();
+__declspec(dllexport) BOOL AddFirewallBlockRule(const wchar_t* exePath);
 
 #ifdef __cplusplus
 }

--- a/NetSeal_Controller/Form1.cs
+++ b/NetSeal_Controller/Form1.cs
@@ -5,6 +5,9 @@ namespace NetSeal_Controller
         [System.Runtime.InteropServices.DllImport("NetSeal.dll", CallingConvention = System.Runtime.InteropServices.CallingConvention.StdCall, CharSet = System.Runtime.InteropServices.CharSet.Ansi)]
         private static extern bool InjectIntoProcess(uint processId, string dllPath);
 
+        [System.Runtime.InteropServices.DllImport("NetSeal.dll", CallingConvention = System.Runtime.InteropServices.CallingConvention.StdCall, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+        private static extern bool AddFirewallBlockRule(string exePath);
+
         public Form1()
         {
             InitializeComponent();
@@ -42,7 +45,22 @@ namespace NetSeal_Controller
 
             var dllPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "NetSeal.dll");
             bool result = InjectIntoProcess(pid, dllPath);
-            MessageBox.Show(result ? "Injected" : "Injection failed");
+
+            bool firewall = false;
+            if (result)
+            {
+                try
+                {
+                    var proc = System.Diagnostics.Process.GetProcessById((int)pid);
+                    firewall = AddFirewallBlockRule(proc.MainModule.FileName);
+                }
+                catch
+                {
+                    firewall = false;
+                }
+            }
+
+            MessageBox.Show(result && firewall ? "Injected and blocked" : "Injection or firewall failed");
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ them in a list box.
 2. The window shows all processes that are accessible to the user.
 3. Select a process and click **Inject**.
 4. The application calls `InjectIntoProcess`, loading `NetSeal.dll` into the
-   selected process. Once loaded, the DLL adds a firewall rule blocking that
-   process's outbound network traffic.
+   selected process. After a successful injection the controller creates a
+   firewall rule blocking that process's outbound network traffic.
 
 ## Internet Blocking
-When the DLL is loaded into a target process, it calls `AddFirewallBlockRule`.
-This function uses the Windows `netsh` command line tool to create a firewall
-rule that blocks all outbound traffic for the current process.
+The controller uses the exported `AddFirewallBlockRule` function to add a
+firewall rule for the selected executable. The rule is created via the Windows
+`netsh` command line tool and blocks all outbound traffic for that process.
 
 ## Test App
 


### PR DESCRIPTION
## Summary
- update firewall API to accept an executable path
- remove firewall rule creation from `DllMain`
- add new P/Invoke call from controller to create firewall rule after injection
- update docs explaining controller adds the rule

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aecfae4ac8330966a29dabeef06a3