### PR TITLE
Improve firewall rule creation

### DIFF
--- a/NetSeal/dllmain.cpp
+++ b/NetSeal/dllmain.cpp
@@ -1,6 +1,5 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "pch.h"
-#include "firewall.h"
 
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
@@ -10,7 +9,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     switch (ul_reason_for_call)
     {
     case DLL_PROCESS_ATTACH:
-        AddFirewallBlockRule();
+        // Rule creation is handled by the injector process
         break;
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:

--- a/NetSeal/firewall.cpp
+++ b/NetSeal/firewall.cpp
@@ -1,16 +1,17 @@
 #include "pch.h"
 #include <string>
 #include <windows.h>
+#include <wchar.h>
+#include <cstdlib>
 
 // Ensure the exported symbol uses C linkage to match the header
 extern "C" {
 
-// Adds a simple Windows Firewall rule to block outbound traffic for the
-// current process. Returns TRUE on success.
-BOOL AddFirewallBlockRule()
+// Adds a Windows Firewall rule to block outbound traffic for the
+// specified executable path. Returns TRUE on success.
+BOOL WINAPI AddFirewallBlockRule(const wchar_t* exePath)
 {
-    wchar_t exePath[MAX_PATH];
-    if (!GetModuleFileNameW(NULL, exePath, MAX_PATH))
+    if (!exePath || wcslen(exePath) == 0)
         return FALSE;
 
     std::wstring command = L"netsh advfirewall firewall add rule name=\"NetSealBlock\" program=\"";

--- a/NetSeal/firewall.h
+++ b/NetSeal/firewall.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-__declspec(dllexport) BOOL AddFirewallBlockRule();
+__declspec(dllexport) BOOL WINAPI AddFirewallBlockRule(const wchar_t* exePath);
 
 #ifdef __cplusplus
 }

--- a/NetSeal/injector.cpp
+++ b/NetSeal/injector.cpp
@@ -2,7 +2,7 @@
 #include "injector.h"
 #include <string>
 
-BOOL InjectIntoProcess(DWORD processId, const char* dllPath)
+BOOL WINAPI InjectIntoProcess(DWORD processId, const char* dllPath)
 {
     HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, processId);
     if (!hProcess)

--- a/NetSeal/injector.h
+++ b/NetSeal/injector.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-__declspec(dllexport) BOOL InjectIntoProcess(DWORD processId, const char* dllPath);
+__declspec(dllexport) BOOL WINAPI InjectIntoProcess(DWORD processId, const char* dllPath);
 
 #ifdef __cplusplus
 }

--- a/NetSeal_Controller/Form1.cs
+++ b/NetSeal_Controller/Form1.cs
@@ -5,6 +5,41 @@ namespace NetSeal_Controller
         [System.Runtime.InteropServices.DllImport("NetSeal.dll", CallingConvention = System.Runtime.InteropServices.CallingConvention.StdCall, CharSet = System.Runtime.InteropServices.CharSet.Ansi)]
         private static extern bool InjectIntoProcess(uint processId, string dllPath);
 
+        [System.Runtime.InteropServices.DllImport("NetSeal.dll", CallingConvention = System.Runtime.InteropServices.CallingConvention.StdCall, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+        private static extern bool AddFirewallBlockRule(string exePath);
+
+        [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+        private static extern bool QueryFullProcessImageName(IntPtr hProcess, int flags, System.Text.StringBuilder text, ref int size);
+
+        [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr OpenProcess(int access, bool inherit, uint pid);
+
+        [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CloseHandle(IntPtr handle);
+
+        private const int PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
+        private static string? GetProcessPath(uint pid)
+        {
+            IntPtr handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
+            if (handle == IntPtr.Zero)
+                return null;
+
+            try
+            {
+                var sb = new System.Text.StringBuilder(1024);
+                int size = sb.Capacity;
+                if (QueryFullProcessImageName(handle, 0, sb, ref size))
+                    return sb.ToString(0, size);
+            }
+            finally
+            {
+                CloseHandle(handle);
+            }
+
+            return null;
+        }
+
         public Form1()
         {
             InitializeComponent();
@@ -42,7 +77,25 @@ namespace NetSeal_Controller
 
             var dllPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "NetSeal.dll");
             bool result = InjectIntoProcess(pid, dllPath);
-            MessageBox.Show(result ? "Injected" : "Injection failed");
+
+            bool firewall = false;
+            if (result)
+            {
+                try
+                {
+                    var path = GetProcessPath(pid);
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        firewall = AddFirewallBlockRule(path);
+                    }
+                }
+                catch
+                {
+                    firewall = false;
+                }
+            }
+
+            MessageBox.Show(result && firewall ? "Injected and blocked" : "Injection or firewall failed");
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ them in a list box.
 2. The window shows all processes that are accessible to the user.
 3. Select a process and click **Inject**.
 4. The application calls `InjectIntoProcess`, loading `NetSeal.dll` into the
-   selected process. Once loaded, the DLL adds a firewall rule blocking that
-   process's outbound network traffic.
+   selected process. After a successful injection the controller creates a
+   firewall rule blocking that process's outbound network traffic.
 
 ## Internet Blocking
-When the DLL is loaded into a target process, it calls `AddFirewallBlockRule`.
-This function uses the Windows `netsh` command line tool to create a firewall
-rule that blocks all outbound traffic for the current process.
+The controller uses the exported `AddFirewallBlockRule` function to add a
+firewall rule for the selected executable. The executable path is retrieved via
+the Windows `QueryFullProcessImageName` API to avoid access issues, then a rule
+is created using `netsh` to block all outbound traffic for that process.
 
 ## Test App
 


### PR DESCRIPTION
## Summary
- ensure exports use `WINAPI` calling convention
- add `<cstdlib>` include and update p/invoke helper functions
- retrieve target exe path using `QueryFullProcessImageName`
- update docs about new approach

## Testing
- `dotnet build NetSeal_Controller/NetSeal_Controller.csproj -c Release` *(fails: command not found)*
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aecfae4ac8330966a29dabeef06a3